### PR TITLE
Proposed fix for JENKINS-13165

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Andrew Bayer 
+Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Andrew Bayer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,18 @@ THE SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.350</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.463</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>clone-workspace-scm</artifactId>
   <packaging>hpi</packaging>
   <name>Jenkins Clone Workspace SCM Plug-in</name>
-  <version>0.5-SNAPSHOT</version>
+  <version>0.5-SNAPSHOT-ronny</version>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Clone+Workspace+SCM+Plugin</url>
   <description>Plugin to archive workspaces from one project and reuse those as SCM sources for other projects.</description>
-  
+
   <licenses>
     <license>
       <name>MIT license</name>
@@ -44,7 +43,7 @@ THE SOFTWARE.
     </license>
   </licenses>
 
-  
+
   <build>
     <pluginManagement>
       <plugins>
@@ -109,5 +108,5 @@ THE SOFTWARE.
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
+</project>
 

--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspacePublisher.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspacePublisher.java
@@ -166,7 +166,11 @@ public class CloneWorkspacePublisher extends Recorder {
                 }
                 // This means we found something.
                 if((includeMsg==null) && (excludeMsg==null)) {
-                    DirScanner globScanner = new DirScanner.Glob(realIncludeGlob, realExcludeGlob);
+                    // See https://issues.jenkins-ci.org/browse/JENKINS-13165 re: Ant 1.8.2+ excluding SCM files by default.
+                    // Don't use any defaults from Ant, and always let user specify (realExcludeGlob)
+                    // WARNING: this assumes Jenkins 1.463 at least.
+                    boolean useDefaultExcludes = false;
+                    DirScanner globScanner = new DirScanner.Glob(realIncludeGlob, realExcludeGlob, useDefaultExcludes);
                     build.addAction(snapshot(build, ws, globScanner, listener, archiveMethod));
 
                     // Find the next most recent build meeting this criteria with an archived snapshot.

--- a/src/main/webapp/workspaceExcludeGlob.html
+++ b/src/main/webapp/workspaceExcludeGlob.html
@@ -1,7 +1,7 @@
 <div>
   <p>Specify the files to exclude from the archive of the build's workspace,
    using wildcards and separators like '**/.svn/**/*, .git/**/*'.
-   See <a href='http://ant.apache.org/manual/CoreTypes/fileset.html'>
+   See <a href='http://ant.apache.org/manual/Types/fileset.html'>
    the @includes of Ant fileset</a> for the exact format.
    The base directory is <a href='ws/'>the workspace</a>.</p>
 </div>

--- a/src/main/webapp/workspaceGlob.html
+++ b/src/main/webapp/workspaceGlob.html
@@ -1,7 +1,7 @@
 <div>
   <p>Specify the files to include in the archive of the build's workspace,
    using wildcards like 'module/dist/**/*.zip'.
-   See <a href='http://ant.apache.org/manual/CoreTypes/fileset.html'>
+   See <a href='http://ant.apache.org/manual/Types/fileset.html'>
    the @includes of Ant fileset</a> for the exact format.
    The base directory is <a href='ws/'>the workspace</a>.</p>
 </div>

--- a/src/test/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCMTest.java
+++ b/src/test/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCMTest.java
@@ -27,9 +27,9 @@ import hudson.FilePath;
 
 import hudson.model.FreeStyleProject;
 import hudson.model.FreeStyleBuild;
-import hudson.model.Label;
 import hudson.model.Result;
 import hudson.model.User;
+import hudson.model.labels.LabelAtom;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
 
@@ -62,12 +62,12 @@ public class CloneWorkspaceSCMTest extends HudsonTestCase {
 
     public void testSlaveCloning() throws Exception {
         FreeStyleProject parentJob = createCloneParentProject();
-        parentJob.setAssignedLabel(createSlave(new Label("parentSlave")).getSelfLabel());
+        parentJob.setAssignedLabel(createSlave(new LabelAtom("parentSlave")).getSelfLabel());
 
         buildAndAssertSuccess(parentJob);
 
         FreeStyleProject childJob = createCloneChildProject();
-        childJob.setAssignedLabel(createSlave(new Label("childSlave")).getSelfLabel());
+        childJob.setAssignedLabel(createSlave(new LabelAtom("childSlave")).getSelfLabel());
         buildAndAssertSuccess(childJob);
 
         FreeStyleBuild fb = childJob.getLastBuild();


### PR DESCRIPTION
This is a proposed fix for https://issues.jenkins-ci.org/browse/JENKINS-13165 re: Ant 1.8.2+ excluding SCM files (like .git) by default.

I made two assumptions which may not be acceptable. So they're open for discussion.
- minimum Jenkins version changed to 1.463
- user must specify explicitly the exclude glob, never use the default excludes (the alternative is probably to make this user configurable, but I'm not familiar enough with Jenkins' codebase)
