### PR TITLE
Fix for JENKINS-13160

### DIFF
--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
@@ -182,6 +182,10 @@ public class CloneWorkspaceSCM extends SCM {
     @Override
     public ChangeLogParser createChangeLogParser() {
         AbstractProject<?,?> p = getContainingProject();
+        if (p == null) {
+            return null;
+        }
+
         final AbstractBuild lastBuild = p.getLastBuild();
         
         try {


### PR DESCRIPTION
JENKINS-13160 Add null check in CloneWorkspaceSCM.createChangeLogParser() to prevent NPE.
