### PR TITLE
Fix for JENKINS-13160

### DIFF
--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
@@ -26,6 +26,7 @@ package hudson.plugins.cloneworkspace;
 import hudson.scm.PollingResult;
 import hudson.scm.SCM;
 import hudson.scm.ChangeLogParser;
+import hudson.scm.NullChangeLogParser;
 import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
 import static hudson.scm.PollingResult.BUILD_NOW;
@@ -182,12 +183,11 @@ public class CloneWorkspaceSCM extends SCM {
     @Override
     public ChangeLogParser createChangeLogParser() {
         AbstractProject<?,?> p = getContainingProject();
-        if (p == null) {
-            return null;
+        AbstractBuild lastBuild = null;
+        if (p != null) {
+            lastBuild = p.getLastBuild();
         }
 
-        final AbstractBuild lastBuild = p.getLastBuild();
-        
         try {
             return resolve(getParamParentJobName(lastBuild)).getParent().getProject().getScm().createChangeLogParser();
         } catch (ResolvedFailedException e) {


### PR DESCRIPTION
Return a NullChangeLogParser in CloneWorkspaceSCM.createChangeLogParser() to prevent NPE.
