### PR TITLE
Adding an option for just a tarball of a project, no compression

### DIFF
--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspacePublisher.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspacePublisher.java
@@ -225,6 +225,15 @@ public class CloneWorkspacePublisher extends Recorder {
             }
 
             return new WorkspaceSnapshotZip();
+        } else if (archiveMethod.equals("TARONLY")) {
+            OutputStream os = new BufferedOutputStream(FilePath.TarCompression.NONE.compress(new FileOutputStream(wss)));
+            try {
+                ws.tar(os, scanner);
+            } finally {
+                os.close();
+            }
+
+            return new WorkspaceSnapshotTarOnly();
         } else {
             OutputStream os = new BufferedOutputStream(FilePath.TarCompression.GZIP.compress(new FileOutputStream(wss)));
             try {
@@ -241,6 +250,13 @@ public class CloneWorkspacePublisher extends Recorder {
         public void restoreTo(AbstractBuild<?,?> owner, FilePath dst, TaskListener listener) throws IOException, InterruptedException {
             File wss = new File(owner.getRootDir(), CloneWorkspaceUtil.getFileNameForMethod("TAR"));
             new FilePath(wss).untar(dst, FilePath.TarCompression.GZIP);
+        }
+    }
+
+    public static final class WorkspaceSnapshotTarOnly extends WorkspaceSnapshot {
+        public void restoreTo(AbstractBuild<?,?> owner, FilePath dst, TaskListener listener) throws IOException, InterruptedException {
+            File wss = new File(owner.getRootDir(), CloneWorkspaceUtil.getFileNameForMethod("TARONLY"));
+            new FilePath(wss).untar(dst, FilePath.TarCompression.NONE);
         }
     }
 

--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceUtil.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceUtil.java
@@ -97,6 +97,8 @@ public class CloneWorkspaceUtil {
     {
         if ("ZIP".equals(method)) {
             return "workspace.zip";
+        } else if ("TARONLY".equals(method)) {
+            return "workspace.tar";
         } else {
             return "workspace.tar.gz";
         }

--- a/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspacePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspacePublisher/config.jelly
@@ -39,6 +39,7 @@ THE SOFTWARE.
   <f:entry title="${%Archive method}" help="/plugin/clone-workspace-scm/archiveMethod.html">
     <select name="archiveMethod">
       <f:option value="TAR" selected='${instance.archiveMethod=="TAR"}'>${%Gzipped tar}</f:option>
+      <f:option value="TARONLY" selected='${instance.archiveMethod=="TARONLY"}'>${%Tarball}</f:option>
       <f:option value="ZIP" selected='${instance.archiveMethod=="ZIP"}'>${%Zipped}</f:option>
     </select>
   </f:entry>

--- a/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspacePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspacePublisher/config.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
   <f:entry title="${%Archive method}" help="/plugin/clone-workspace-scm/archiveMethod.html">
     <select name="archiveMethod">
       <f:option value="TAR" selected='${instance.archiveMethod=="TAR"}'>${%Gzipped tar}</f:option>
-      <f:option value="TARONLY" selected='${instance.archiveMethod=="TARONLY"}'>${%Tarball}</f:option>
+      <f:option value="TARONLY" selected='${instance.archiveMethod=="TARONLY"}'>${%Tar}</f:option>
       <f:option value="ZIP" selected='${instance.archiveMethod=="ZIP"}'>${%Zipped}</f:option>
     </select>
   </f:entry>


### PR DESCRIPTION
Our workspace is 1.6GB as a tarball and only compresses to 1.1GB, but we spend a long time during the build doing that compression / decompression.
