### PR TITLE
JENKINS-9779: Adding the job's parameters to the list of possible parents

### DIFF
--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
@@ -48,6 +48,7 @@ import hudson.WorkspaceSnapshot;
 import hudson.PermalinkList;
 import hudson.Extension;
 import static hudson.Util.fixEmptyAndTrim;
+import org.apache.commons.collections.ListUtils;
 
 import java.io.IOException;
 import java.io.File;
@@ -63,6 +64,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import net.sf.json.JSONObject;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersDefinitionProperty;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
@@ -207,6 +207,18 @@ public class CloneWorkspaceSCM extends SCM {
         return null;
     }
                 
+    public List<String> getParameterList() {
+        ArrayList<String> list = new ArrayList<String>();
+        ParametersDefinitionProperty prop = (ParametersDefinitionProperty) getContainingProject().getProperty(ParametersDefinitionProperty.class);
+        if (prop != null) {
+            for (ParameterDefinition param : prop.getParameterDefinitions())
+                list.add("$" + param.getName());
+        }
+        return list;
+    }
+     public List<String> getParentAndParamList() {
+         return ListUtils.union(getDescriptor().getEligibleParents(), getParameterList());
+     }
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl)super.getDescriptor();

--- a/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspaceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspaceSCM/config.jelly
@@ -21,12 +21,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%Parent Project}" help="/plugin/clone-workspace-scm/parentJobName.html">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Parent job selection}" help="/plugin/clone-workspace-scm/parentJobName.html">
     <select name="parentJobName">
       <j:if test="${!empty(descriptor.getEligibleParents())}">
-        <j:forEach var="parentProject" items="${descriptor.getEligibleParents()}">
+                <j:forEach var="parentProject" items="${scm.getParentAndParamList()}">
           <f:option value="${parentProject}" selected="${scm.parentJobName==parentProject}">${parentProject}</f:option>
         </j:forEach>
       </j:if>

--- a/src/main/webapp/parentJobName.html
+++ b/src/main/webapp/parentJobName.html
@@ -1,3 +1,4 @@
 <div>
-  <p>If any projects have the Clone Workspace Publisher enabled, they will show up in this menu. Choose one to use as the SCM source for this project.</p>
+  <p>If any projects have the Clone Workspace Publisher enabled, they will show up in this list. Choose one to use as the SCM source for this project.</p>
+  <p>The list also shows this job's parameters. You can use a parameter to pass the name of the parent job. Make sure the paremeter is set to the name of a project with the Clone Workspace Publisher enabled.</p>
 </div>


### PR DESCRIPTION
This is so you can actually use a parameter to pass in the parent job's name
