### PR TITLE
Converted fixed select control to more flexible editable combobox.

### DIFF
--- a/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspaceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/cloneworkspace/CloneWorkspaceSCM/config.jelly
@@ -24,13 +24,7 @@ THE SOFTWARE.
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Parent Project}" help="/plugin/clone-workspace-scm/parentJobName.html">
-    <select name="parentJobName">
-      <j:if test="${!empty(descriptor.getEligibleParents())}">
-        <j:forEach var="parentProject" items="${descriptor.getEligibleParents()}">
-          <f:option value="${parentProject}" selected="${scm.parentJobName==parentProject}">${parentProject}</f:option>
-        </j:forEach>
-      </j:if>
-    </select>
+    <f:editableComboBox field="parentJobName" items="${descriptor.getEligibleParents()}"/>
   </f:entry>
 
   <f:entry title="${%Criteria for parent build}" help="/plugin/clone-workspace-scm/childCriteria.html">


### PR DESCRIPTION
I have encountered a use case where I need to be able to inject the source of the clone through a parameter (instead of selecting the source at project creation).  Discovered a handy editable combobox control that lets me do that while retaining the original selector functionality (and it's actually much simpler than the previous layout).
