### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath></relativePath>
   </parent>
 
@@ -43,20 +43,12 @@ THE SOFTWARE.
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>markewaite</id>
-      <name>Mark Waite</name>
-      <email>mark.earl.waite@gmail.com</email>
-    </developer>
-  </developers>
-
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/jenkins-clone-workspace-scm-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
   </properties>
 
   <dependencyManagement>
@@ -64,7 +56,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4051.v78dce3ce8b_d6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspacePublisher.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspacePublisher.java
@@ -40,7 +40,7 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.DirScanner;
 import hudson.util.FormValidation;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
@@ -268,7 +268,7 @@ public class CloneWorkspacePublisher extends Recorder {
         }
 
         @Override
-        public CloneWorkspacePublisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public CloneWorkspacePublisher newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return req.bindJSON(CloneWorkspacePublisher.class,formData);
         }
 

--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
@@ -70,7 +70,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import net.sf.json.JSONObject;
 
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -331,7 +331,7 @@ public class CloneWorkspaceSCM extends SCM {
 
         
         @Override
-        public SCM newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public SCM newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return req.bindJSON(CloneWorkspaceSCM.class, formData);
         }
 

--- a/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
+++ b/src/main/java/hudson/plugins/cloneworkspace/CloneWorkspaceSCM.java
@@ -340,8 +340,7 @@ public class CloneWorkspaceSCM extends SCM {
             
             for (AbstractProject p : Hudson.getInstance().getAllItems(AbstractProject.class)) {
                 if (p.getPublishersList().get(CloneWorkspacePublisher.class) != null) {
-                    if (p instanceof MatrixProject) {
-                        MatrixProject mp = (MatrixProject) p;
+                    if (p instanceof MatrixProject mp) {
                         for (MatrixConfiguration configuration : mp.getActiveConfigurations()) {
                             parentNames.add(configuration.getFullName());
                         }


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

### Testing done

Confirmed that tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
